### PR TITLE
finally fixed the middleware by using jose

### DIFF
--- a/heroes-of-hearthglow/package-lock.json
+++ b/heroes-of-hearthglow/package-lock.json
@@ -38,6 +38,7 @@
         "googleapis": "^140.0.1",
         "jest": "^29.7.0",
         "jest-fetch-mock": "^3.0.3",
+        "jose": "^5.6.3",
         "jsonwebtoken": "^9.0.2",
         "mongodb-memory-server": "^9.3.0",
         "mongoose": "^8.4.1",
@@ -9910,9 +9911,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.7",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.7.tgz",
-      "integrity": "sha512-L7ioP+JAuZe8v+T5+zVI9Tx8LtU8BL7NxkyDFVMv+Qr3JW0jSoYDedLtodaXwfqMpeCyx4WXFNyu9tJt4WvC1A==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+      "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10988,6 +10989,16 @@
         }
       }
     },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -11452,6 +11463,16 @@
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }

--- a/heroes-of-hearthglow/package.json
+++ b/heroes-of-hearthglow/package.json
@@ -51,6 +51,7 @@
     "googleapis": "^140.0.1",
     "jest": "^29.7.0",
     "jest-fetch-mock": "^3.0.3",
+    "jose": "^5.6.3",
     "jsonwebtoken": "^9.0.2",
     "mongodb-memory-server": "^9.3.0",
     "mongoose": "^8.4.1",


### PR DESCRIPTION
Trying to protect my API routes has been a wild ride. After **a lot** of trial and error and fighting with vercel versioning i finally found the core issue of why i never could verify authentication with the middleware. It's because JWT isnt supported in the next edge runtime environment. So instead i used a Web crypto API calles Jose that can verify my JWT when trying to reach the relevant API endpoints.