### PR TITLE
Remove keen-slider dependency from package.json

### DIFF
--- a/heroes-of-hearthglow/package.json
+++ b/heroes-of-hearthglow/package.json
@@ -26,7 +26,6 @@
     "@nextui-org/react": "^2.4.2",
     "framer-motion": "^11.2.10",
     "js-cookie": "^3.0.5",
-    "keen-slider": "^6.8.6",
     "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
The keen-slider package is no longer needed and has been removed to clean up the project's dependencies. This helps reduce the package size and potential security vulnerabilities.